### PR TITLE
fix: SegmentArena recovery under append_return_values + RelocateAllDictionaries no-op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Both branches support Stwo prover opcodes (Blake2s, QM31) since v2.0.0.
 ---
 
 #### Upcoming Changes
+* fix: recover SegmentArena across `--append_return_values` rescopes and no-op `RelocateAllDictionaries` when no dict was allocated
+
 * ci: pin GitHub Actions to commit SHAs and bump deprecated `upload-artifact`/`download-artifact` to v4 [#2388](https://github.com/starkware-libs/cairo-vm/pull/2388)
 
 * fix: remove feature mod_builtin [#2387](https://github.com/starkware-libs/cairo-vm/pull/2387)

--- a/cairo1-run/src/cairo_run.rs
+++ b/cairo1-run/src/cairo_run.rs
@@ -455,6 +455,7 @@ After calling this function (before running the VM):
     (*1+2+3) gap
     (*1+2) gap
     (*1+2) gap
+    (*1+2) gap
     (*2) gap
     (*2) gap
     (*2) gap
@@ -475,6 +476,7 @@ After the entry_code (up until calling main) has been ran by the VM:
     (*1) gap (for output_builtin final ptr)
     (*1) gap (for builtin_0 final ptr)
     (*1) gap (for builtin_1 final ptr)
+    (*1+2) gap (for final SegmentArena ptr)
     (*2) segment_arena_ptr
     (*2) infos_ptr
     (*2) 0
@@ -506,6 +508,8 @@ fn load_arguments(
     // These include:
     // * The builtin bases (not including output)
     // * (Only if the output builtin is added) A gap for each builtin's final pointer
+    // * (Only if the output builtin is added and SegmentArena is present) A gap for the
+    //   final SegmentArena pointer
     // * The segment arena values (if present), including:
     //  * segment_arena_ptr
     //  * info_segment_ptr
@@ -514,6 +518,10 @@ fn load_arguments(
     let mut ap_offset = runner.get_program().builtins_len();
     if cairo_run_config.copy_to_output() {
         ap_offset += runner.get_program().builtins_len() - 1;
+        // Extra local reserved for the final SegmentArena pointer (see create_entry_code).
+        if got_segment_arena {
+            ap_offset += 1;
+        }
     }
     if got_segment_arena {
         ap_offset += SEGMENT_ARENA_GAPS;
@@ -595,7 +603,14 @@ fn create_entry_code(
         for _ in 0..builtins.len() {
             casm_build_extend!(ctx, tempvar _local;);
         }
-        casm_build_extend!(ctx, ap += builtins.len(););
+        // Extra FP-stable local for SegmentArena (not in `builtins`). Output-serialization
+        // `rescope`s drop AP-relative vars; this cell survives them. Placed after builtin
+        // locals so it sits at [fp + builtins.len()]. `ap +=` includes it so AP sits past
+        // the local rather than on it.
+        if got_segment_arena {
+            casm_build_extend!(ctx, tempvar _segment_arena_local;);
+        }
+        casm_build_extend!(ctx, ap += builtins.len() + got_segment_arena as usize;);
     }
     let mut expected_arguments_size = 0;
     if got_segment_arena {
@@ -701,6 +716,15 @@ fn create_entry_code(
             let local = ctx.add_var(CellExpression::Deref(deref!([fp + i.to_i16().unwrap()])));
             casm_build_extend!(ctx, assert local = var;);
         }
+        // Preserve SegmentArena across output-serialization `rescope`s in the dedicated
+        // local at [fp + builtins.len()] reserved above.
+        if got_segment_arena {
+            let sa_local = ctx.add_var(CellExpression::Deref(deref!([
+                fp + builtins.len().to_i16().unwrap()
+            ])));
+            let var = get_var(&BuiltinName::segment_arena);
+            casm_build_extend!(ctx, assert sa_local = var;);
+        }
         // Serialize return values into output segment
         let output_ptr = output_ptr.unwrap();
         let outputs = (1..(return_type_size + 1))
@@ -753,9 +777,11 @@ fn create_entry_code(
             // We lost the output_ptr var after re-scoping, so we need to create it again
             // The last instruction will write the last output ptr so we can find it in [ap - 1]
             let output_ptr = ctx.add_var(CellExpression::Deref(deref!([ap - 1])));
-            // len(builtins - output) + len(builtins) + if segment_arena: segment_arena_ptr +
+            // len(builtins - output) + len(builtins) + segment_arena_local +
             // info_ptr + 0 + (segment_arena_ptr + 3) + (gas_builtin) + (system_builtin)
+            // (+1 for the dedicated SegmentArena local when present)
             let offset = (2 * builtins.len() - 1
+                + got_segment_arena as usize // dedicated SA local
                 + 4 * got_segment_arena as usize
                 + got_gas_builtin as usize
                 + got_system_builtin as usize) as i16;
@@ -792,18 +818,17 @@ fn create_entry_code(
                 EndInputCopy:
             };
         }
-        // After we are done writing into the output segment, we can write the final output_ptr into locals:
-        // The last instruction will write the final output ptr so we can find it in [ap - 1]
+        // After output serialization:
+        // - [ap-1] holds the final output_ptr — write it to [fp+0] before validation
+        //   advances AP (validation uses empty rescopes; FP-relative cells survive).
+        // - SegmentArena was saved at [fp + builtins.len()].
         let output_ptr = ctx.add_var(CellExpression::Deref(deref!([ap - 1])));
         let local = ctx.add_var(CellExpression::Deref(deref!([fp])));
         casm_build_extend!(ctx, assert local = output_ptr;);
-
         if got_segment_arena {
-            // We re-scoped when serializing the output so we have to create a var for the segment arena
-            // len(builtins) + len(builtins - output) + segment_arena_ptr + info_segment + 0
-            let off = 2 * builtins.len() + 2;
-            let segment_arena_ptr = ctx.add_var(CellExpression::Deref(deref!([fp + off as i16])));
-            // Call the hint that will relocate all dictionaries
+            let segment_arena_ptr = ctx.add_var(CellExpression::Deref(deref!([
+                fp + builtins.len().to_i16().unwrap()
+            ])));
             ctx.add_hint(
                 |[ignored_in], [ignored_out]| StarknetHint::Cheatcode {
                     selector: BigIntAsHex {
@@ -851,6 +876,7 @@ fn create_entry_code(
                 DONE_VALIDATION:
             };
         }
+
         // Copying the final builtins from locals into the top of the stack.
         for i in 0..builtins.len().to_i16().unwrap() {
             let local = ctx.add_var(CellExpression::Deref(deref!([fp + i])));
@@ -1629,6 +1655,7 @@ mod tests {
     #[case("../cairo_programs/cairo-1-programs/serialized_output/array_append.cairo")]
     #[case("../cairo_programs/cairo-1-programs/serialized_output/array_get.cairo")]
     #[case("../cairo_programs/cairo-1-programs/serialized_output/dictionaries.cairo")]
+    #[case("../cairo_programs/cairo-1-programs/serialized_output/dict_poseidon.cairo")]
     #[case("../cairo_programs/cairo-1-programs/serialized_output/enum_flow.cairo")]
     #[case("../cairo_programs/cairo-1-programs/serialized_output/enum_match.cairo")]
     #[case("../cairo_programs/cairo-1-programs/serialized_output/factorial.cairo")]

--- a/cairo1-run/src/main.rs
+++ b/cairo1-run/src/main.rs
@@ -355,6 +355,27 @@ mod tests {
     #[case("with_input/branching.cairo", "0", "[0]", Some("17"), Some("[17]"))]
     #[case("with_input/branching.cairo", "1", "[1]", Some("0"), Some("[0]"))]
     #[case("dictionaries.cairo", "1024", "[1024]", None, None)]
+    #[case(
+        "dict_poseidon.cairo",
+        "1602489809172823862257873759490616802956072677226904159421257053405288194985",
+        "[1602489809172823862257873759490616802956072677226904159421257053405288194985]",
+        None,
+        None
+    )]
+    #[case(
+        "with_input/dict_untaken_branch.cairo",
+        "42",
+        "[42]",
+        Some("0"),
+        Some("[0]")
+    )]
+    #[case(
+        "with_input/dict_untaken_branch.cairo",
+        "1",
+        "[1]",
+        Some("1"),
+        Some("[1]")
+    )]
     #[case("simple_struct.cairo", "100", "[100]", None, None)]
     #[case("simple.cairo", "true", "[1]", None, None)]
     #[case(

--- a/cairo_programs/cairo-1-programs/dict_poseidon.cairo
+++ b/cairo_programs/cairo-1-programs/dict_poseidon.cairo
@@ -1,0 +1,9 @@
+use core::poseidon::hades_permutation;
+
+fn main() -> felt252 {
+    let mut d: Felt252Dict<felt252> = Default::default();
+    d.insert(0, 0);
+    let (h, _, _) = hades_permutation(7, 0, 0);
+    let _b = 1_u32 & 1_u32;
+    h
+}

--- a/cairo_programs/cairo-1-programs/serialized_output/dict_poseidon.cairo
+++ b/cairo_programs/cairo-1-programs/serialized_output/dict_poseidon.cairo
@@ -1,0 +1,11 @@
+use core::poseidon::hades_permutation;
+
+fn main() -> Array<felt252> {
+    let mut d: Felt252Dict<felt252> = Default::default();
+    d.insert(0, 0);
+    let (h, _, _) = hades_permutation(7, 0, 0);
+    let _b = 1_u32 & 1_u32;
+    let mut output: Array<felt252> = ArrayTrait::new();
+    h.serialize(ref output);
+    output
+}

--- a/cairo_programs/cairo-1-programs/serialized_output/with_input/dict_untaken_branch.cairo
+++ b/cairo_programs/cairo-1-programs/serialized_output/with_input/dict_untaken_branch.cairo
@@ -1,0 +1,16 @@
+fn dict_path(input: Span<felt252>) -> felt252 {
+    let mut d: Felt252Dict<felt252> = Default::default();
+    d.insert(0, *input[0]);
+    d[0]
+}
+
+fn main(input: Array<felt252>) -> Array<felt252> {
+    let res = if *input[0] == 1 {
+        dict_path(input.span())
+    } else {
+        42
+    };
+    let mut output: Array<felt252> = ArrayTrait::new();
+    res.serialize(ref output);
+    output
+}

--- a/cairo_programs/cairo-1-programs/with_input/dict_untaken_branch.cairo
+++ b/cairo_programs/cairo-1-programs/with_input/dict_untaken_branch.cairo
@@ -1,0 +1,13 @@
+fn dict_path(x: felt252) -> felt252 {
+    let mut d: Felt252Dict<felt252> = Default::default();
+    d.insert(0, x);
+    d[0]
+}
+
+fn main(flag: felt252) -> felt252 {
+    if flag == 1 {
+        dict_path(flag)
+    } else {
+        42
+    }
+}

--- a/vm/src/hint_processor/cairo_1_hint_processor/dict_manager.rs
+++ b/vm/src/hint_processor/cairo_1_hint_processor/dict_manager.rs
@@ -135,7 +135,11 @@ impl DictManagerExecScope {
                         .into_boxed_str(),
                 ));
             }
+            // Arena validation asserts `curr_start = prev_end + 1`. Advance past the
+            // first dict's end before placing the next one; each iteration does the
+            // same after writing the relocation.
             let mut prev_end = first_segment.end.unwrap_or_default();
+            prev_end += 1;
             for tracker in &self.trackers[1..] {
                 if tracker.start.segment_index >= 0 {
                     return Err(HintError::CustomHint(

--- a/vm/src/hint_processor/cairo_1_hint_processor/hint_processor.rs
+++ b/vm/src/hint_processor/cairo_1_hint_processor/hint_processor.rs
@@ -299,9 +299,18 @@ impl Cairo1HintProcessor {
                 })?;
                 match selector {
                     "RelocateAllDictionaries" => {
-                        let dict_manager_exec_scope = exec_scopes
-                            .get_mut_ref::<DictManagerExecScope>("dict_manager_exec_scope")?;
-                        dict_manager_exec_scope.relocate_all_dictionaries(vm)
+                        // Dict code may be present in the Sierra program (so SegmentArena
+                        // is an implicit) without any dict being allocated on the taken
+                        // path. In that case the exec scope was never created — no-op.
+                        match exec_scopes
+                            .get_mut_ref::<DictManagerExecScope>("dict_manager_exec_scope")
+                        {
+                            Ok(dict_manager_exec_scope) => {
+                                dict_manager_exec_scope.relocate_all_dictionaries(vm)
+                            }
+                            Err(HintError::VariableNotInScopeError(_)) => Ok(()),
+                            Err(e) => Err(e),
+                        }
                     }
                     _ => Err(HintError::UnknownHint(selector.into())),
                 }


### PR DESCRIPTION
When running Cairo 1 programs with `--append_return_values` (or proof mode), two related bugs in the exit wrapper caused failures for programs that use dictionaries together with other builtins, or that contain dict code on untaken branches.

### Bug 1 — SegmentArena pointer recovered from a fragile FP offset

**Symptom**

Programs whose `main` carries **SegmentArena and Poseidon** (and often Bitwise) fail arena finalization:

```text
VirtualMachine(Math(RelocatableSubUsizeNegOffset((Relocatable { segment_index: N, offset: 0 }, 2))))
```

or:

```text
VirtualMachine(Memory(AddressNotRelocatable))
```

**Minimal repro**

```cairo
use core::dict::{Felt252Dict, Felt252DictTrait};
use core::poseidon::hades_permutation;

pub fn main(input: Array<felt252>) -> Array<felt252> {
    let mut d: Felt252Dict<felt252> = Default::default();
    Felt252DictTrait::insert(ref d, 0, 0);
    let (h, _, _) = hades_permutation(*input[0], 0, 0);
    let _b = 1_u32 & 1_u32; // optional; Bitwise also triggers
    array![h]
}
```

```bash
scarb build  # enable-gas = false recommended for cairo1-run
cairo1-run target/dev/<pkg>.sierra.json \
  --layout all_cairo \
  --append_return_values \
  --cairo_pie_output /tmp/pie.zip \
  --args '[7]'
```

**Why it failed**

After `main` returns, the exit wrapper serializes the return (and input) array into the output segment. That path uses `rescope{…}` blocks, which drop AP-relative CASM variables — including the live SegmentArena pointer.

The wrapper then tried to recover the pointer with a hard-coded offset:

```text
fp + 2 * builtins.len() + 2
```

That cell was the **initial** SegmentArena implicit (`base+3`), not the pointer `main` returned. Dict alloc/destruct copies the 3-cell header forward, so `ptr[-2]` on `base+3` reads the stale header zeros and arena validation becomes a no-op. Extra builtins (Poseidon / Bitwise) or gas shift that FP cell onto a felt or a segment base; `segment_arena_ptr[-2]` then crashes.

| Program                  | Result (before)         |
| ------------------------ | ----------------------- |
| dict only                | OK (validation skipped) |
| poseidon only            | OK                      |
| dict + hades_permutation | **FAIL**                |
| dict + hades + bitwise   | **FAIL**                |

**Fix**

Reserve a dedicated FP-stable local at entry (`[fp + builtins.len()]`), save the final SegmentArena pointer there **before** output-serialization rescopes, and read it back for `RelocateAllDictionaries` / arena validation. Update `load_arguments` (+1 to `ap_offset` when SegmentArena is present) and the input-serialization FP offset so user args stay aligned.

Using the final pointer means arena validation actually runs. `RelocateAllDictionaries` already left a one-cell gap between later dicts (`prev_end += 1`) to match `assert curr_start = prev_end + one`, but the first relocated dict was placed at `first.end` with no gap. Advance `prev_end` by one before that first relocation.

### Bug 2 — `RelocateAllDictionaries` when no dict was allocated

**Symptom**

```text
VirtualMachine(Hint((0, VariableNotInScopeError("dict_manager_exec_scope"))))
```

**Minimal repro**

```cairo
use core::dict::{Felt252Dict, Felt252DictTrait};

fn dict_path(input: Span<felt252>) -> felt252 {
    let mut d: Felt252Dict<felt252> = Default::default();
    Felt252DictTrait::insert(ref d, 0, *input[0]);
    Felt252DictTrait::get(ref d, 0)
}

pub fn main(input: Array<felt252>) -> Array<felt252> {
    if *input[0] == 1 {
        array![dict_path(input.span())]
    } else {
        array![42]
    }
}
```

```bash
# fails
cairo1-run … --append_return_values --args '[0]'
# succeeds
cairo1-run … --append_return_values --args '[1]'
```

**Why it failed**

Using `Felt252Dict` anywhere in the Sierra program adds a SegmentArena implicit, so the exit wrapper always injects `RelocateAllDictionaries`. That hint required `dict_manager_exec_scope`, which is only created when a dict allocation hint actually runs. On the `[0]` path no dict is allocated → scope missing → crash. Dict allocation hints already lazy-init the scope; the relocate cheatcode did not.

**Fix**

Make `RelocateAllDictionaries` a no-op when `dict_manager_exec_scope` is absent (nothing to relocate). Behavior is unchanged when a dict was used.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo-vm/2389)
<!-- Reviewable:end -->
