### PR TITLE
perf: reduce per-instruction overhead in VM execution hot paths

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -119,43 +119,43 @@ jobs:
         path: cairo_programs/proof_programs/
 
     - name: Fetch test programs
-      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: cairo_test_programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'vm/src/tests/cairo_test_suite/**/*.cairo', 'Makefile', 'requirements.txt') }}
         fail-on-cache-miss: true
     - name: Fetch proof programs
-      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: cairo_proof_programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'vm/src/tests/cairo_test_suite/**/*.cairo', 'Makefile', 'requirements.txt') }}
         fail-on-cache-miss: true
     - name: Fetch bench programs
-      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: cairo_bench_programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'vm/src/tests/cairo_test_suite/**/*.cairo', 'Makefile', 'requirements.txt') }}
         fail-on-cache-miss: true
     - name: Fetch cairo test suite programs
-      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: cairo_test_suite_programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'vm/src/tests/cairo_test_suite/**/*.cairo', 'Makefile', 'requirements.txt') }}
         fail-on-cache-miss: true
     - name: Fetch test contracts (Cairo 1)
-      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: cairo_1_test_contracts-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'vm/src/tests/cairo_test_suite/**/*.cairo', 'Makefile', 'requirements.txt') }}
         fail-on-cache-miss: true
     - name: Fetch test contracts (Cairo 2)
-      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: cairo_2_test_contracts-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'vm/src/tests/cairo_test_suite/**/*.cairo', 'Makefile', 'requirements.txt') }}
         fail-on-cache-miss: true
     - name: Merge caches
-      uses: actions/cache/save@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: all-programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'vm/src/tests/cairo_test_suite/**/*.cairo', 'Makefile', 'requirements.txt') }}
@@ -184,7 +184,7 @@ jobs:
 
 
     - name: Fetch programs
-      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: all-programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'vm/src/tests/cairo_test_suite/**/*.cairo', 'Makefile', 'requirements.txt') }}
@@ -238,7 +238,7 @@ jobs:
         path: cairo_programs/proof_programs/
 
     - name: Fetch programs
-      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: all-programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'vm/src/tests/cairo_test_suite/**/*.cairo', 'Makefile', 'requirements.txt') }}
@@ -283,7 +283,7 @@ jobs:
         path: cairo_programs/proof_programs/
 
     - name: Fetch programs
-      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: all-programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'vm/src/tests/cairo_test_suite/**/*.cairo', 'Makefile', 'requirements.txt') }}
@@ -318,7 +318,7 @@ jobs:
         path: cairo_programs/proof_programs/
 
     - name: Fetch programs
-      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: all-programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'vm/src/tests/cairo_test_suite/**/*.cairo', 'Makefile', 'requirements.txt') }}
@@ -344,7 +344,7 @@ jobs:
             --workspace --features "cairo-1-hints, test_utils, ${{ matrix.special_features }}"
 
     - name: Save coverage
-      uses: actions/cache/save@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: lcov-${{ matrix.target }}-${{ matrix.special_features }}.info
         key: codecov-cache-${{ matrix.target }}-${{ matrix.special_features }}-${{ github.sha }}
@@ -363,7 +363,7 @@ jobs:
       run: cargo b --release -p cairo-vm-cli
     # We don't read from cache because it should always miss
     - name: Store in cache
-      uses: actions/cache/save@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: cli-bin-rel-${{ github.sha }}
         path: target/release/cairo-vm-cli
@@ -418,7 +418,7 @@ jobs:
 
     - name: Fetch programs
       if: steps.trace-cache.outputs.cache-hit != 'true'
-      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: ${{ matrix.program-target }}-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'vm/src/tests/cairo_test_suite/**/*.cairo', 'Makefile', 'requirements.txt') }}
@@ -453,7 +453,7 @@ jobs:
       uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
     - name: Fetch release binary
-      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: cli-bin-rel-${{ github.sha }}
         path: target/release/cairo-vm-cli
@@ -465,7 +465,7 @@ jobs:
         path: cairo_programs/proof_programs/
 
     - name: Fetch programs
-      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: ${{ matrix.program-target }}-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'vm/src/tests/cairo_test_suite/**/*.cairo', 'Makefile', 'requirements.txt') }}
@@ -479,7 +479,7 @@ jobs:
         --memory_file '{program}'.rs.memory --trace_file '{program}'.rs.trace --fill-holes false \
         ${{ matrix.extra-args }}
     - name: Update cache
-      uses: actions/cache/save@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: |
           cairo_programs/**/*.memory
@@ -499,73 +499,73 @@ jobs:
       uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
     - name: Fetch results for tests with stdlib (part. 1)
-      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: lcov-test#1-.info
         key: codecov-cache-test#1--${{ github.sha }}
         fail-on-cache-miss: true
     - name: Fetch results for tests with stdlib (part. 2)
-      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: lcov-test#2-.info
         key: codecov-cache-test#2--${{ github.sha }}
         fail-on-cache-miss: true
     - name: Fetch results for tests with stdlib (part. 3)
-      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: lcov-test#3-.info
         key: codecov-cache-test#3--${{ github.sha }}
         fail-on-cache-miss: true
     - name: Fetch results for tests with stdlib (part. 4)
-      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: lcov-test#4-.info
         key: codecov-cache-test#4--${{ github.sha }}
         fail-on-cache-miss: true
     - name: Fetch results for tests with stdlib (w/extensive_hints; part. 1)
-      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: lcov-test#1-extensive_hints.info
         key: codecov-cache-test#1-extensive_hints-${{ github.sha }}
         fail-on-cache-miss: true
     - name: Fetch results for tests with stdlib (w/extensive_hints; part. 2)
-      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: lcov-test#2-extensive_hints.info
         key: codecov-cache-test#2-extensive_hints-${{ github.sha }}
         fail-on-cache-miss: true
     - name: Fetch results for tests with stdlib (w/extensive_hints; part. 3)
-      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: lcov-test#3-extensive_hints.info
         key: codecov-cache-test#3-extensive_hints-${{ github.sha }}
         fail-on-cache-miss: true
     - name: Fetch results for tests with stdlib (w/extensive_hints; part. 4)
-      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: lcov-test#4-extensive_hints.info
         key: codecov-cache-test#4-extensive_hints-${{ github.sha }}
         fail-on-cache-miss: true
     - name: Fetch results for tests with stdlib (w/cairo-0-secp-hints; part. 1)
-      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: lcov-test#1-cairo-0-secp-hints.info
         key: codecov-cache-test#1-cairo-0-secp-hints-${{ github.sha }}
         fail-on-cache-miss: true
     - name: Fetch results for tests with stdlib (w/cairo-0-secp-hints; part. 2)
-      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: lcov-test#2-cairo-0-secp-hints.info
         key: codecov-cache-test#2-cairo-0-secp-hints-${{ github.sha }}
         fail-on-cache-miss: true
     - name: Fetch results for tests with stdlib (w/cairo-0-secp-hints; part. 3)
-      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: lcov-test#3-cairo-0-secp-hints.info
         key: codecov-cache-test#3-cairo-0-secp-hints-${{ github.sha }}
         fail-on-cache-miss: true
     - name: Fetch results for tests with stdlib (w/cairo-0-secp-hints; part. 4)
-      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: lcov-test#4-cairo-0-secp-hints.info
         key: codecov-cache-test#4-cairo-0-secp-hints-${{ github.sha }}
@@ -595,7 +595,7 @@ jobs:
         path: cairo_programs/proof_programs/
 
     - name: Fetch traces for cairo-lang
-      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: |
           cairo_programs/**/*.memory
@@ -607,7 +607,7 @@ jobs:
         fail-on-cache-miss: true
 
     - name: Fetch traces for cairo-vm
-      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: |
           cairo_programs/**/*.memory
@@ -648,7 +648,7 @@ jobs:
           echo PATH=$PATH >> $GITHUB_ENV
 
     - name: Fetch release binary
-      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: cli-bin-rel-${{ github.sha }}
         path: target/release/cairo-vm-cli
@@ -660,7 +660,7 @@ jobs:
         path: cairo_programs/proof_programs/
 
     - name: Fetch programs
-      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: cairo_proof_programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'vm/src/tests/cairo_test_suite/**/*.cairo', 'Makefile', 'requirements.txt') }}
@@ -688,7 +688,7 @@ jobs:
           echo PATH=$PATH >> $GITHUB_ENV
 
     - name: Fetch release binary
-      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: cli-bin-rel-${{ github.sha }}
         path: target/release/cairo-vm-cli
@@ -700,14 +700,14 @@ jobs:
         path: cairo_programs/proof_programs/
 
     - name: Fetch programs
-      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: cairo_proof_programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'vm/src/tests/cairo_test_suite/**/*.cairo', 'Makefile', 'requirements.txt') }}
         fail-on-cache-miss: true
 
     - name: Fetch pie
-      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: |
           cairo_programs/**/*.memory
@@ -740,14 +740,14 @@ jobs:
           echo PATH=$PATH >> $GITHUB_ENV
 
     - name: Fetch release binary
-      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         key: cli-bin-rel-${{ github.sha }}
         path: target/release/cairo-vm-cli
         fail-on-cache-miss: true
 
     - name: Fetch traces for cairo-vm
-      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: |
           cairo_programs/**/*.memory

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -137,7 +137,7 @@ jobs:
         key: cairo_bench_programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'vm/src/tests/cairo_test_suite/**/*.cairo', 'Makefile', 'requirements.txt') }}
         fail-on-cache-miss: true
     - name: Fetch cairo test suite programs
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}
         key: cairo_test_suite_programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'vm/src/tests/cairo_test_suite/**/*.cairo', 'Makefile', 'requirements.txt') }}
@@ -198,8 +198,12 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      # NOTE: installed and run directly: the bnjbvr/cargo-machete action internally uses
+      # clechasseur/rs-cargo by tag, which the org's action-pinning policy rejects.
+      - name: Install machete
+        run: cargo install cargo-machete --locked --version 0.9.1
       - name: Machete
-        uses: bnjbvr/cargo-machete@7959c845782fed02ee69303126d4a12d64f1db18 # v0.9.1
+        run: cargo machete
 
   # NOTE: the term "smoke test" comes from electronics design: the minimal
   # expectations anyone has in their device is to not catch fire on boot.

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -137,6 +137,9 @@ jobs:
         key: cairo_bench_programs-cache-${{ hashFiles('cairo_programs/**/*.cairo', 'vm/src/tests/cairo_test_suite/**/*.cairo', 'Makefile', 'requirements.txt') }}
         fail-on-cache-miss: true
     - name: Fetch cairo test suite programs
+      # The test suite directory is currently empty, so its build saves no cache and this
+      # restore can never hit; skip it until the suite has programs.
+      if: ${{ hashFiles('vm/src/tests/cairo_test_suite/**/*.cairo') != '' }}
       uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ${{ env.CAIRO_PROGRAMS_PATH }}

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -37,10 +37,10 @@ jobs:
           make check
 
   install_debian:
-    name: "Install on debian-11"
+    name: "Install on debian-12"
     runs-on: ubuntu-24.04
     container:
-      image: debian:11
+      image: debian:12
     defaults:
       run:
         shell: bash {0}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Both branches support Stwo prover opcodes (Blake2s, QM31) since v2.0.0.
 ---
 
 #### Upcoming Changes
+* perf: reduce per-instruction overhead in VM execution hot paths (memory get/insert, range-check validation, instruction cache, operand deduction) [#2391](https://github.com/starkware-libs/cairo-vm/pull/2391)
+
 * ci: pin GitHub Actions to commit SHAs and bump deprecated `upload-artifact`/`download-artifact` to v4 [#2388](https://github.com/starkware-libs/cairo-vm/pull/2388)
 
 * fix: remove feature mod_builtin [#2387](https://github.com/starkware-libs/cairo-vm/pull/2387)

--- a/vm/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
+++ b/vm/src/hint_processor/builtin_hint_processor/builtin_hint_processor_definition.rs
@@ -199,14 +199,18 @@ impl HintProcessorLogic for BuiltinHintProcessor {
             .ok_or(HintError::WrongHintData)?;
         let constants = hint_data.constants.as_ref();
 
-        if let Some(hint_func) = self.extra_hints.get(&hint_data.code) {
-            return hint_func.0(
-                vm,
-                exec_scopes,
-                &hint_data.ids_data,
-                &hint_data.ap_tracking,
-                constants,
-            );
+        // Hashing the full hint code on every execution is expensive; skip the lookup entirely
+        // in the common case where no extra hints were registered.
+        if !self.extra_hints.is_empty() {
+            if let Some(hint_func) = self.extra_hints.get(&hint_data.code) {
+                return hint_func.0(
+                    vm,
+                    exec_scopes,
+                    &hint_data.ids_data,
+                    &hint_data.ap_tracking,
+                    constants,
+                );
+            }
         }
         match &*hint_data.code {
             hint_code::ADD_SEGMENT => add_segment(vm),

--- a/vm/src/vm/runners/builtin_runner/range_check.rs
+++ b/vm/src/vm/runners/builtin_runner/range_check.rs
@@ -7,13 +7,10 @@ use crate::{
 
 use crate::Felt252;
 use crate::{
-    types::relocatable::{MaybeRelocatable, Relocatable},
+    types::relocatable::MaybeRelocatable,
     vm::{
         errors::memory_errors::MemoryError,
-        vm_memory::{
-            memory::{Memory, ValidationRule},
-            memory_segments::MemorySegmentManager,
-        },
+        vm_memory::{memory::Memory, memory_segments::MemorySegmentManager},
     },
 };
 
@@ -104,22 +101,7 @@ impl<const N_PARTS: u64> RangeCheckBuiltinRunner<N_PARTS> {
     }
 
     pub fn add_validation_rule(&self, memory: &mut Memory) {
-        let rule = ValidationRule(Box::new(
-            |memory: &Memory, address: Relocatable| -> Result<Vec<Relocatable>, MemoryError> {
-                let num = memory
-                    .get_integer(address)
-                    .map_err(|_| MemoryError::RangeCheckFoundNonInt(Box::new(address)))?;
-                if num.bits() as u64 <= N_PARTS * INNER_RC_BOUND_SHIFT {
-                    Ok(vec![address.to_owned()])
-                } else {
-                    Err(MemoryError::RangeCheckNumOutOfBounds(Box::new((
-                        num.into_owned(),
-                        Felt252::TWO.pow((N_PARTS * INNER_RC_BOUND_SHIFT) as u128),
-                    ))))
-                }
-            },
-        ));
-        memory.add_validation_rule(self.base, rule);
+        memory.add_range_check_validation_rule(self.base, N_PARTS * INNER_RC_BOUND_SHIFT);
     }
 
     pub fn get_used_cells(&self, segments: &MemorySegmentManager) -> Result<usize, MemoryError> {
@@ -179,6 +161,7 @@ mod tests {
     use super::*;
     use crate::relocatable;
     use crate::types::builtin_name::BuiltinName;
+    use crate::types::relocatable::Relocatable;
     use crate::vm::errors::runner_errors::RunnerError;
     use crate::vm::vm_memory::memory::Memory;
     use crate::{

--- a/vm/src/vm/vm_core.rs
+++ b/vm/src/vm/vm_core.rs
@@ -263,11 +263,11 @@ impl VirtualMachine {
     fn update_registers(
         &mut self,
         instruction: &Instruction,
-        operands: Operands,
+        operands: &Operands,
     ) -> Result<(), VirtualMachineError> {
-        self.update_fp(instruction, &operands)?;
-        self.update_ap(instruction, &operands)?;
-        self.update_pc(instruction, &operands)?;
+        self.update_fp(instruction, operands)?;
+        self.update_ap(instruction, operands)?;
+        self.update_pc(instruction, operands)?;
         Ok(())
     }
 
@@ -322,7 +322,7 @@ impl VirtualMachine {
         &self,
         instruction: &Instruction,
         dst: Option<&MaybeRelocatable>,
-        op0: Option<MaybeRelocatable>,
+        op0: Option<&MaybeRelocatable>,
     ) -> Result<(Option<MaybeRelocatable>, Option<MaybeRelocatable>), VirtualMachineError> {
         if let Opcode::AssertEq = instruction.opcode {
             match instruction.res {
@@ -330,7 +330,7 @@ impl VirtualMachine {
                 Res::Add => {
                     return Ok((
                         dst.zip(op0).and_then(|(dst, op0)| {
-                            typed_sub(dst, &op0, instruction.opcode_extension).ok()
+                            typed_sub(dst, op0, instruction.opcode_extension).ok()
                         }),
                         dst.cloned(),
                     ))
@@ -340,7 +340,7 @@ impl VirtualMachine {
                         Some(MaybeRelocatable::Int(num_dst)),
                         Some(MaybeRelocatable::Int(num_op0)),
                     ) if !num_op0.is_zero() => {
-                        let num_op1 = typed_div(num_dst, &num_op0, instruction.opcode_extension)?;
+                        let num_op1 = typed_div(num_dst, num_op0, instruction.opcode_extension)?;
                         return Ok((Some(MaybeRelocatable::Int(num_op1)), dst.cloned()));
                     }
                     _ => (),
@@ -518,7 +518,7 @@ impl VirtualMachine {
                 .or_insert(0) += 1;
         }
 
-        self.update_registers(instruction, operands)?;
+        self.update_registers(instruction, &operands)?;
         self.current_step += 1;
 
         Ok(())
@@ -636,7 +636,7 @@ impl VirtualMachine {
     }
 
     pub fn step_instruction(&mut self) -> Result<(), VirtualMachineError> {
-        if self.run_context.pc.segment_index == 0 {
+        let instruction = if self.run_context.pc.segment_index == 0 {
             // Run instructions from program segment, using instruction cache
             let pc = self.run_context.pc.offset;
 
@@ -644,32 +644,27 @@ impl VirtualMachine {
                 return Err(MemoryError::UnknownMemoryCell(Box::new((0, pc).into())))?;
             }
 
-            let mut inst_cache = core::mem::take(&mut self.instruction_cache);
-            inst_cache.resize((pc + 1).max(inst_cache.len()), None);
-
-            let instruction = inst_cache.get_mut(pc).unwrap();
-            if instruction.is_none() {
-                *instruction = Some(self.decode_current_instruction()?);
+            if self.instruction_cache.len() <= pc {
+                self.instruction_cache.resize(pc + 1, None);
             }
-            let instruction = instruction.as_ref().unwrap();
-
-            if !self.skip_instruction_execution {
-                self.run_instruction(instruction)?;
-            } else {
-                self.run_context.pc += instruction.size();
-                self.skip_instruction_execution = false;
+            match self.instruction_cache[pc] {
+                Some(instruction) => instruction,
+                None => {
+                    let instruction = self.decode_current_instruction()?;
+                    self.instruction_cache[pc] = Some(instruction);
+                    instruction
+                }
             }
-            self.instruction_cache = inst_cache;
         } else {
             // Run instructions from programs loaded in other segments, without instruction cache
-            let instruction = self.decode_current_instruction()?;
+            self.decode_current_instruction()?
+        };
 
-            if !self.skip_instruction_execution {
-                self.run_instruction(&instruction)?;
-            } else {
-                self.run_context.pc += instruction.size();
-                self.skip_instruction_execution = false;
-            }
+        if !self.skip_instruction_execution {
+            self.run_instruction(&instruction)?;
+        } else {
+            self.run_context.pc += instruction.size();
+            self.skip_instruction_execution = false;
         }
         Ok(())
     }
@@ -733,7 +728,7 @@ impl VirtualMachine {
         let op1_op = match self.deduce_memory_cell(op1_addr)? {
             None => {
                 let (op1, deduced_res) =
-                    self.deduce_op1(instruction, dst_op.as_ref(), Some(op0.clone()))?;
+                    self.deduce_op1(instruction, dst_op.as_ref(), Some(op0))?;
                 if res.is_none() {
                     *res = deduced_res
                 }
@@ -2174,7 +2169,7 @@ mod tests {
         vm.run_context.fp = 6;
 
         assert_matches!(
-            vm.update_registers(&instruction, operands),
+            vm.update_registers(&instruction, &operands),
             Ok::<(), VirtualMachineError>(())
         );
         assert_eq!(vm.run_context.pc, Relocatable::from((0, 5)));
@@ -2210,7 +2205,7 @@ mod tests {
         run_context!(vm, 4, 5, 6);
 
         assert_matches!(
-            vm.update_registers(&instruction, operands),
+            vm.update_registers(&instruction, &operands),
             Ok::<(), VirtualMachineError>(())
         );
         assert_eq!(vm.run_context.pc, Relocatable::from((0, 12)));
@@ -2580,7 +2575,7 @@ mod tests {
         let dst = MaybeRelocatable::Int(Felt252::from(3));
         let op0 = MaybeRelocatable::Int(Felt252::from(2));
         assert_matches!(
-            vm.deduce_op1(&instruction, Some(&dst), Some(op0)),
+            vm.deduce_op1(&instruction, Some(&dst), Some(&op0)),
             Ok::<(Option<MaybeRelocatable>, Option<MaybeRelocatable>), VirtualMachineError>((
                 x,
                 y
@@ -2637,7 +2632,7 @@ mod tests {
         let dst = MaybeRelocatable::Int(Felt252::from(4));
         let op0 = MaybeRelocatable::Int(Felt252::from(2));
         assert_matches!(
-            vm.deduce_op1(&instruction, Some(&dst), Some(op0)),
+            vm.deduce_op1(&instruction, Some(&dst), Some(&op0)),
             Ok::<(Option<MaybeRelocatable>, Option<MaybeRelocatable>), VirtualMachineError>((
                 x,
                 y
@@ -2668,7 +2663,7 @@ mod tests {
         let dst = MaybeRelocatable::Int(Felt252::from(4));
         let op0 = MaybeRelocatable::Int(Felt252::from(0));
         assert_matches!(
-            vm.deduce_op1(&instruction, Some(&dst), Some(op0)),
+            vm.deduce_op1(&instruction, Some(&dst), Some(&op0)),
             Ok::<(Option<MaybeRelocatable>, Option<MaybeRelocatable>), VirtualMachineError>((
                 None, None
             ))
@@ -2696,7 +2691,7 @@ mod tests {
 
         let op0 = MaybeRelocatable::Int(Felt252::from(0));
         assert_matches!(
-            vm.deduce_op1(&instruction, None, Some(op0)),
+            vm.deduce_op1(&instruction, None, Some(&op0)),
             Ok::<(Option<MaybeRelocatable>, Option<MaybeRelocatable>), VirtualMachineError>((
                 None, None
             ))
@@ -2757,7 +2752,7 @@ mod tests {
         let op0 = MaybeRelocatable::Int(op0_qm31.pack_into_felt());
         let dst = MaybeRelocatable::Int(dst_qm31.pack_into_felt());
         assert_matches!(
-            vm.deduce_op1(&instruction, Some(&dst), Some(op0)),
+            vm.deduce_op1(&instruction, Some(&dst), Some(&op0)),
             Ok::<(Option<MaybeRelocatable>, Option<MaybeRelocatable>), VirtualMachineError>((
                 x,
                 y
@@ -2790,7 +2785,7 @@ mod tests {
         let op0 = MaybeRelocatable::Int(op0_qm31.pack_into_felt());
         let dst = MaybeRelocatable::Int(dst_qm31.pack_into_felt());
         assert_matches!(
-            vm.deduce_op1(&instruction, Some(&dst), Some(op0)),
+            vm.deduce_op1(&instruction, Some(&dst), Some(&op0)),
             Ok::<(Option<MaybeRelocatable>, Option<MaybeRelocatable>), VirtualMachineError>((
                 x,
                 y
@@ -2821,7 +2816,7 @@ mod tests {
         let op0 = MaybeRelocatable::Int(Felt252::from(4));
         let dst = MaybeRelocatable::Int(Felt252::from(16));
         assert_matches!(
-            vm.deduce_op1(&instruction, Some(&dst), Some(op0)),
+            vm.deduce_op1(&instruction, Some(&dst), Some(&op0)),
             Err(VirtualMachineError::InvalidTypedOperationOpcodeExtension(ref message)) if message.as_ref() == "typed_div"
         );
     }

--- a/vm/src/vm/vm_core.rs
+++ b/vm/src/vm/vm_core.rs
@@ -488,16 +488,12 @@ impl VirtualMachine {
             max.max(off0).max(off1).max(off2),
         ));
 
-        self.segments
-            .memory
-            .mark_as_accessed(operands_addresses.dst_addr);
-        self.segments
-            .memory
-            .mark_as_accessed(operands_addresses.op0_addr);
-        self.segments
-            .memory
-            .mark_as_accessed(operands_addresses.op1_addr);
-        self.segments.memory.mark_as_accessed(self.run_context.pc);
+        self.segments.memory.mark_as_accessed_batch([
+            operands_addresses.dst_addr,
+            operands_addresses.op0_addr,
+            operands_addresses.op1_addr,
+            self.run_context.pc,
+        ]);
 
         if instruction.opcode_extension == OpcodeExtension::Blake
             || instruction.opcode_extension == OpcodeExtension::BlakeFinalize

--- a/vm/src/vm/vm_memory/memory.rs
+++ b/vm/src/vm/vm_memory/memory.rs
@@ -17,6 +17,17 @@ pub struct ValidationRule(
     pub  Box<dyn Fn(&Memory, Relocatable) -> Result<Vec<Relocatable>, MemoryError>>,
 );
 
+/// Internal representation of validation rules: common built-in rules get a
+/// dedicated variant that can be checked inline, without going through a boxed
+/// closure or allocating the resulting address list.
+enum InnerValidationRule {
+    Closure(ValidationRule),
+    /// Value must be a felt of at most `n_bits` bits.
+    RangeCheck {
+        n_bits: u64,
+    },
+}
+
 /// [`MemoryCell`] represents an optimized storage layout for the VM memory.
 /// It's specified to have both size an alignment of 32 bytes to optimize cache access.
 /// Typical cache sizes are 64 bytes, a few cases might be 128 bytes, meaning 32 bytes aligned to
@@ -172,7 +183,7 @@ pub struct Memory {
     #[cfg(feature = "extensive_hints")]
     pub(crate) relocation_rules: HashMap<usize, MaybeRelocatable>,
     pub validated_addresses: AddressSet,
-    validation_rules: Vec<Option<ValidationRule>>,
+    validation_rules: Vec<Option<InnerValidationRule>>,
 }
 
 impl Memory {
@@ -207,8 +218,16 @@ impl Memory {
         MaybeRelocatable: From<V>,
     {
         let val = MaybeRelocatable::from(val);
-        let segment = self.get_segment(key)?;
-        let (_, value_offset) = from_relocatable_to_indexes(key);
+        let (value_index, value_offset) = from_relocatable_to_indexes(key);
+        let data = if key.segment_index.is_negative() {
+            &mut self.temp_data
+        } else {
+            &mut self.data
+        };
+        let data_len = data.len();
+        let segment = data
+            .get_mut(value_index)
+            .ok_or_else(|| MemoryError::UnallocatedSegment(Box::new((value_index, data_len))))?;
 
         //Check if the element is inserted next to the last one on the segment
         //Forgoing this check would allow data to be inserted in a different index
@@ -269,7 +288,19 @@ impl Memory {
             .get_segment_cells(relocatable.segment_index)?
             .get(relocatable.offset)?
             .get_value()?;
-        Some(Cow::Owned(self.relocate_value(&value).ok()?.into_owned()))
+        // Only values pointing into a temporary segment can be affected by relocation rules,
+        // so skip the relocation machinery for everything else.
+        Some(match value {
+            MaybeRelocatable::RelocatableValue(addr) if addr.segment_index < 0 => {
+                #[cfg(not(feature = "extensive_hints"))]
+                let v = self.relocate_value(addr).ok()?.into();
+                #[cfg(feature = "extensive_hints")]
+                let v = self.relocate_value(addr).ok()?;
+
+                Cow::Owned(v)
+            }
+            value => Cow::Owned(value),
+        })
     }
 
     // Version of Memory.relocate_value() that doesn't require a self reference
@@ -577,6 +608,17 @@ impl Memory {
     }
 
     pub fn add_validation_rule(&mut self, segment_index: usize, rule: ValidationRule) {
+        self.add_inner_validation_rule(segment_index, InnerValidationRule::Closure(rule));
+    }
+
+    /// Adds a range-check validation rule for the given segment: every value inserted into it
+    /// must be a felt of at most `n_bits` bits. Checked inline, avoiding the allocations of the
+    /// closure-based rules.
+    pub(crate) fn add_range_check_validation_rule(&mut self, segment_index: usize, n_bits: u64) {
+        self.add_inner_validation_rule(segment_index, InnerValidationRule::RangeCheck { n_bits });
+    }
+
+    fn add_inner_validation_rule(&mut self, segment_index: usize, rule: InnerValidationRule) {
         if segment_index >= self.validation_rules.len() {
             // Fill gaps
             self.validation_rules
@@ -586,34 +628,47 @@ impl Memory {
     }
 
     fn validate_memory_cell(&mut self, addr: Relocatable) -> Result<(), MemoryError> {
-        if let Some(Some(rule)) = addr
+        match addr
             .segment_index
             .to_usize()
             .and_then(|x| self.validation_rules.get(x))
         {
-            if !self.validated_addresses.contains(&addr) {
-                self.validated_addresses
-                    .extend(rule.0(self, addr)?.as_slice());
+            Some(Some(InnerValidationRule::RangeCheck { n_bits })) => {
+                let n_bits = *n_bits;
+                if !self.validated_addresses.contains(&addr) {
+                    let num = self
+                        .get_integer(addr)
+                        .map_err(|_| MemoryError::RangeCheckFoundNonInt(Box::new(addr)))?
+                        .into_owned();
+                    if num.bits() as u64 > n_bits {
+                        return Err(MemoryError::RangeCheckNumOutOfBounds(Box::new((
+                            num,
+                            Felt252::TWO.pow(n_bits as u128),
+                        ))));
+                    }
+                    self.validated_addresses.extend(&[addr]);
+                }
             }
+            Some(Some(InnerValidationRule::Closure(rule))) => {
+                if !self.validated_addresses.contains(&addr) {
+                    self.validated_addresses
+                        .extend(rule.0(self, addr)?.as_slice());
+                }
+            }
+            _ => {}
         }
         Ok(())
     }
 
     ///Applies validation_rules to the current memory
     pub fn validate_existing_memory(&mut self) -> Result<(), MemoryError> {
-        for (index, rule) in self.validation_rules.iter().enumerate() {
-            if index >= self.data.len() {
+        for index in 0..self.validation_rules.len() {
+            if index >= self.data.len() || self.validation_rules[index].is_none() {
                 continue;
             }
-            let Some(rule) = rule else {
-                continue;
-            };
             for offset in 0..self.data[index].len() {
                 let addr = Relocatable::from((index as isize, offset));
-                if !self.validated_addresses.contains(&addr) {
-                    self.validated_addresses
-                        .extend(rule.0(self, addr)?.as_slice());
-                }
+                self.validate_memory_cell(addr)?;
             }
         }
         Ok(())

--- a/vm/src/vm/vm_memory/memory.rs
+++ b/vm/src/vm/vm_memory/memory.rs
@@ -81,6 +81,14 @@ impl MemoryCell {
     pub fn get_value(&self) -> Option<MaybeRelocatable> {
         self.is_some().then(|| (*self).into())
     }
+
+    /// Compares the values held by two cells, ignoring the ACCESS flag.
+    /// Both the felt and the relocatable encodings are canonical, so comparing the raw words is
+    /// equivalent to comparing the corresponding `MaybeRelocatable`s.
+    pub fn eq_value(&self, other: &Self) -> bool {
+        let mask = !Self::ACCESS_MASK;
+        (self.0[0] & mask, &self.0[1..]) == (other.0[0] & mask, &other.0[1..])
+    }
 }
 
 impl From<MaybeRelocatable> for MemoryCell {
@@ -243,19 +251,18 @@ impl Memory {
         }
         // At this point there's *something* in there
 
-        match segment[value_offset].get_value() {
-            None => segment[value_offset] = MemoryCell::new(val),
-            Some(current_cell) => {
-                if current_cell != val {
-                    //Existing memory cannot be changed
-                    return Err(MemoryError::InconsistentMemory(Box::new((
-                        key,
-                        current_cell,
-                        val,
-                    ))));
-                }
-            }
-        };
+        let new_cell = MemoryCell::new(val);
+        let cell = &mut segment[value_offset];
+        if cell.is_none() {
+            *cell = new_cell;
+        } else if !cell.eq_value(&new_cell) {
+            //Existing memory cannot be changed
+            return Err(MemoryError::InconsistentMemory(Box::new((
+                key,
+                (*cell).into(),
+                new_cell.into(),
+            ))));
+        }
         self.validate_memory_cell(key)
     }
 
@@ -854,6 +861,31 @@ impl Memory {
         let cell = data.get_mut(i).and_then(|x| x.get_mut(j));
         if let Some(cell) = cell {
             cell.mark_accessed()
+        }
+    }
+
+    /// Marks a batch of addresses as accessed, resolving each segment only once for runs of
+    /// consecutive addresses sharing a segment.
+    pub(crate) fn mark_as_accessed_batch<const N: usize>(&mut self, addrs: [Relocatable; N]) {
+        let mut i = 0;
+        while i < N {
+            let segment_index = addrs[i].segment_index;
+            let (data_index, _) = from_relocatable_to_indexes(addrs[i]);
+            let data = if segment_index < 0 {
+                &mut self.temp_data
+            } else {
+                &mut self.data
+            };
+            let mut segment = data.get_mut(data_index);
+            while i < N && addrs[i].segment_index == segment_index {
+                if let Some(cell) = segment
+                    .as_deref_mut()
+                    .and_then(|segment| segment.get_mut(addrs[i].offset))
+                {
+                    cell.mark_accessed();
+                }
+                i += 1;
+            }
         }
     }
 
@@ -2003,6 +2035,42 @@ mod memory_tests {
         assert!(!memory.data[0][0].is_accessed());
         memory.mark_as_accessed(relocatable!(0, 0));
         assert!(memory.data[0][0].is_accessed());
+    }
+
+    #[test]
+    fn mark_address_as_accessed_batch() {
+        let mut memory = memory![((0, 0), 0), ((0, 1), 1), ((1, 0), 2), ((1, 1), 3)];
+        // Runs of same-segment addresses, an unknown cell and an unallocated segment.
+        memory.mark_as_accessed_batch([
+            relocatable!(1, 0),
+            relocatable!(1, 1),
+            relocatable!(0, 1),
+            relocatable!(0, 5),
+            relocatable!(7, 0),
+        ]);
+        assert!(!memory.data[0][0].is_accessed());
+        assert!(memory.data[0][1].is_accessed());
+        assert!(memory.data[1][0].is_accessed());
+        assert!(memory.data[1][1].is_accessed());
+    }
+
+    #[test]
+    fn memory_cell_eq_value_ignores_access_flag() {
+        let felt_cell = MemoryCell::new(MaybeRelocatable::from(Felt252::from(7)));
+        let mut accessed_felt_cell = felt_cell;
+        accessed_felt_cell.mark_accessed();
+        assert!(felt_cell.eq_value(&accessed_felt_cell));
+        assert!(accessed_felt_cell.eq_value(&felt_cell));
+
+        let other_felt_cell = MemoryCell::new(MaybeRelocatable::from(Felt252::from(8)));
+        assert!(!felt_cell.eq_value(&other_felt_cell));
+
+        let reloc_cell = MemoryCell::new(MaybeRelocatable::from((1, 2)));
+        let mut accessed_reloc_cell = reloc_cell;
+        accessed_reloc_cell.mark_accessed();
+        assert!(reloc_cell.eq_value(&accessed_reloc_cell));
+        assert!(!reloc_cell.eq_value(&MemoryCell::new(MaybeRelocatable::from((1, 3)))));
+        assert!(!reloc_cell.eq_value(&felt_cell));
     }
 
     #[test]


### PR DESCRIPTION
Reduces per-instruction overhead in the VM execution hot paths:

- **`Memory::get`**: skip the relocation round-trip and redundant 40-byte copy for values that cannot be affected by relocation rules (everything except pointers into temporary segments). Hits 3–4 reads per instruction.
- **`Memory::insert`**: compute segment indexes once instead of twice, and compare `MemoryCell`s directly (ignoring the ACCESS flag) instead of materializing a `MaybeRelocatable` for the consistency check.
- **Range-check validation**: validate inline instead of via a boxed closure, removing a heap allocation per range-checked value.
- **`step_instruction`**: drop the per-step `mem::take` + `resize` of the instruction cache; copy the (`Copy`) `Instruction` out instead. Also keeps the cache intact if `run_instruction` errors.
- **`deduce_op1`**: take `op0` by reference, avoiding a felt clone per deduced operand.
- **`update_registers`**: take operands by reference instead of by value (~168-byte move per step).
- **`BuiltinHintProcessor`**: skip hashing the full hint source on every hint execution when no extra hints are registered.
- **`mark_as_accessed`**: batch the four per-step address marks, resolving each segment once for consecutive same-segment addresses.

Measured on `cairo_programs/benchmarks` (best-of-5, `--layout all_cairo --proof_mode`): −10% to −32% wall clock on most benchmarks (big_fibonacci −32%, pedersen −28%, linear_search −20%, keccak_integration −18%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Performance

**Expected:** removes per-instruction overhead on every VM step — 3–4 relocation round-trips + 40-byte copies per step in `Memory::get`, a heap alloc per range-checked value, a `mem::take`+`resize` per step in the instruction cache, a felt clone per deduced operand, a ~168-byte operands move per step, a full-source hash per hint execution, and redundant index computations in `insert`/`mark_as_accessed`. Applies to essentially every workload; biggest where steps are cheap (tight loops) so per-step overhead dominates.

**Measured** (best-of-7, wall clock vs `main`, local; noise ±2.4%):

| benchmark | delta | | benchmark | delta |
|---|---|---|---|---|
| poseidon_integration | −20.2% | | keccak_integration | −14.5% |
| pedersen | −20.4% | | big_factorial | −13.2% |
| linear_search | −20.7% | | memory_integration | −13.2% |
| big_fibonacci | −16.3% | | math_integration | −9.3% |
| integration_builtins | −14.0% | | secp_integration | −7.7% |
| uint256_integration | −14.0% | | dict_integration | −7.3% |

Every benchmark improves, −7% to −21%. An independent earlier measurement on a different machine (4-core container, best-of-5, before the `insert`/`mark_as_accessed` commits were added) showed the same shape: big_fibonacci −32%, pedersen −28%, linear_search −20%, keccak −18%, dict −16%, big_factorial −13%, math −10%.

*Methodology: `cairo_programs/benchmarks/*.cairo` compiled with cairo-lang 0.14 `--proof_mode`, run via `cairo-vm-cli <prog>.json --layout all_cairo --proof_mode`, hyperfine best-of-7 per binary, local x86-64 Linux. Noise floor (identical-code control pair): ±2.4%.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo-vm/2391)
<!-- Reviewable:end -->

