### PR TITLE
perf: cache compiled hint data on the runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Both branches support Stwo prover opcodes (Blake2s, QM31) since v2.0.0.
 ---
 
 #### Upcoming Changes
+* perf: compile the program's hints once per `CairoRunner` instead of on every run call; proof-mode trace padding no longer recompiles all hints per padding step [#2393](https://github.com/starkware-libs/cairo-vm/pull/2393)
+
 * fix: `run_for_steps` now executes the hints of every pc it visits; previously it reused the hints of the entry pc for all steps [#2392](https://github.com/starkware-libs/cairo-vm/pull/2392)
 
 * perf: reduce per-instruction overhead in VM execution hot paths (memory get/insert, range-check validation, instruction cache, operand deduction) [#2391](https://github.com/starkware-libs/cairo-vm/pull/2391)

--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -232,6 +232,11 @@ pub struct CairoRunner {
     pub relocated_memory: Vec<Option<Felt252>>,
     pub exec_scopes: ExecutionScopes,
     pub relocated_trace: Option<Vec<RelocatedTraceEntry>>,
+    /// The program's hints, compiled on the first run call and reused by subsequent ones,
+    /// avoiding recompiling every hint each time a run method is called (e.g. the
+    /// `run_for_steps` calls of proof-mode trace padding). Assumes the same hint processor
+    /// is used across the runner's run calls.
+    hint_data: Option<Vec<Box<dyn Any>>>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -267,6 +272,7 @@ impl CairoRunner {
                 None
             },
             relocated_trace: None,
+            hint_data: None,
         }
     }
 
@@ -781,11 +787,13 @@ impl CairoRunner {
         address: Relocatable,
         hint_processor: &mut dyn HintProcessor,
     ) -> Result<(), VirtualMachineError> {
-        let references = &self.program.shared_program_data.reference_manager;
-        #[cfg(not(feature = "extensive_hints"))]
-        let hint_data = self.get_hint_data(references, hint_processor)?;
-        #[cfg(feature = "extensive_hints")]
-        let mut hint_data = self.get_hint_data(references, hint_processor)?;
+        if self.hint_data.is_none() {
+            self.hint_data = Some(self.get_hint_data(
+                &self.program.shared_program_data.reference_manager,
+                hint_processor,
+            )?);
+        }
+        let hint_data = self.hint_data.get_or_insert_with(Vec::new);
         #[cfg(feature = "extensive_hints")]
         let mut hint_ranges = self
             .program
@@ -794,13 +802,13 @@ impl CairoRunner {
             .hints_ranges
             .clone();
         #[cfg(feature = "test_utils")]
-        self.vm.execute_before_first_step(&hint_data)?;
+        self.vm.execute_before_first_step(hint_data)?;
         while self.vm.get_pc() != address && !hint_processor.consumed() {
             self.vm.step(
                 hint_processor,
                 &mut self.exec_scopes,
                 #[cfg(feature = "extensive_hints")]
-                &mut hint_data,
+                hint_data,
                 #[cfg(not(feature = "extensive_hints"))]
                 self.program
                     .shared_program_data
@@ -832,11 +840,13 @@ impl CairoRunner {
         steps: usize,
         hint_processor: &mut dyn HintProcessor,
     ) -> Result<(), VirtualMachineError> {
-        let references = &self.program.shared_program_data.reference_manager;
-        #[cfg(not(feature = "extensive_hints"))]
-        let hint_data = self.get_hint_data(references, hint_processor)?;
-        #[cfg(feature = "extensive_hints")]
-        let mut hint_data = self.get_hint_data(references, hint_processor)?;
+        if self.hint_data.is_none() {
+            self.hint_data = Some(self.get_hint_data(
+                &self.program.shared_program_data.reference_manager,
+                hint_processor,
+            )?);
+        }
+        let hint_data = self.hint_data.get_or_insert_with(Vec::new);
         #[cfg(feature = "extensive_hints")]
         let mut hint_ranges = self
             .program
@@ -853,7 +863,7 @@ impl CairoRunner {
                 hint_processor,
                 &mut self.exec_scopes,
                 #[cfg(feature = "extensive_hints")]
-                &mut hint_data,
+                hint_data,
                 #[cfg(not(feature = "extensive_hints"))]
                 self.program
                     .shared_program_data


### PR DESCRIPTION
`get_hint_data` compiled every hint in the program on each run call; proof-mode trace padding calls `run_for_steps`/`run_until_next_power_of_2` in a loop, recompiling all hints per padding step. Compile once on first use and reuse across the runner's run calls (assumes the same hint processor across a runner's runs).

Based on #2392.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo-vm/2393)
<!-- Reviewable:end -->
