### PR TITLE
perf: lookup builtin runner by segment in operand deduction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Both branches support Stwo prover opcodes (Blake2s, QM31) since v2.0.0.
 ---
 
 #### Upcoming Changes
+* perf: replace the linear builtin-runner scan in operand deduction with a lazily-rebuilt segment lookup. BREAKING: `VirtualMachine::builtin_runners` and `simulated_builtin_runners` are no longer public fields — use `get_builtin_runners`/`get_builtin_runners_as_mut`/`get_simulated_builtin_runners`/`get_simulated_builtin_runners_as_mut`; `compute_operands` now takes `&mut self` [#2394](https://github.com/starkware-libs/cairo-vm/pull/2394)
+
 * perf: reduce per-instruction overhead in VM execution hot paths (memory get/insert, range-check validation, instruction cache, operand deduction) [#2391](https://github.com/starkware-libs/cairo-vm/pull/2391)
 
 * ci: pin GitHub Actions to commit SHAs and bump deprecated `upload-artifact`/`download-artifact` to v4 [#2388](https://github.com/starkware-libs/cairo-vm/pull/2388)

--- a/vm/src/vm/runners/cairo_runner.rs
+++ b/vm/src/vm/runners/cairo_runner.rs
@@ -581,6 +581,7 @@ impl CairoRunner {
         for builtin_runner in self.vm.builtin_runners.iter_mut() {
             builtin_runner.initialize_segments(&mut self.vm.segments);
         }
+        self.vm.mark_builtin_runners_changed();
     }
 
     fn initialize_state(
@@ -5650,7 +5651,7 @@ mod tests {
         builtin_runner.initialize_segments(&mut cairo_runner.vm.segments);
         cairo_runner
             .vm
-            .simulated_builtin_runners
+            .get_simulated_builtin_runners_as_mut()
             .push(builtin_runner);
 
         let hint_processor: &mut dyn HintProcessor = &mut BuiltinHintProcessor::new_empty();

--- a/vm/src/vm/vm_core.rs
+++ b/vm/src/vm/vm_core.rs
@@ -124,7 +124,10 @@ impl Default for VirtualMachineConfig {
 
 pub struct VirtualMachine {
     pub(crate) run_context: RunContext,
-    pub builtin_runners: Vec<BuiltinRunner>,
+    /// NOTE: any mutation that can change a runner's base or the set of runners must be
+    /// followed by a call to `mark_builtin_runners_changed`, so that the segment lookup is
+    /// rebuilt (the public mut accessors already do so).
+    pub(crate) builtin_runners: Vec<BuiltinRunner>,
     /// A simulated builtin is being verified in the executed Cairo
     /// code (so proving them only involves proving cairo steps), rather
     /// than being outputted as their own segment and proven later using
@@ -135,7 +138,14 @@ pub struct VirtualMachine {
     /// needs a mechanism for obtaining the segment pointer. See example
     /// implementation of this mechanism in `simulated_builtins.cairo`, or
     /// cairo-lang's `simple_bootloader.cairo`.
-    pub simulated_builtin_runners: Vec<BuiltinRunner>,
+    /// NOTE: see the mutation note on `builtin_runners`.
+    pub(crate) simulated_builtin_runners: Vec<BuiltinRunner>,
+    /// Maps a segment index to the runner (as an index into the
+    /// `builtin_runners` ++ `simulated_builtin_runners` chain) whose base is that segment,
+    /// or `NO_BUILTIN` for segments without one. Rebuilt lazily when
+    /// `builtin_lookup_dirty` is set.
+    builtin_segment_lookup: Vec<u32>,
+    builtin_lookup_dirty: bool,
     pub(crate) extended_resource_counter: HashMap<ExtendedExecutionResourceType, usize>,
     pub segments: MemorySegmentManager,
     pub(crate) trace: Option<Vec<TraceEntry>>,
@@ -176,6 +186,8 @@ impl VirtualMachine {
             run_context,
             builtin_runners: Vec::new(),
             simulated_builtin_runners: Vec::new(),
+            builtin_segment_lookup: Vec::new(),
+            builtin_lookup_dirty: true,
             extended_resource_counter: HashMap::new(),
             trace,
             current_step: 0,
@@ -351,24 +363,60 @@ impl VirtualMachine {
         Ok((None, None))
     }
 
-    fn deduce_memory_cell(
-        &self,
-        address: Relocatable,
-    ) -> Result<Option<MaybeRelocatable>, VirtualMachineError> {
-        let memory = &self.segments.memory;
+    /// Sentinel in `builtin_segment_lookup` for segments that have no builtin runner.
+    const NO_BUILTIN: u32 = u32::MAX;
 
-        for runner in self
+    /// Marks the builtin runner segment lookup as outdated; it will be rebuilt on the next
+    /// deduction. Must be called after any mutation that can change a runner's base or the
+    /// set of runners.
+    pub fn mark_builtin_runners_changed(&mut self) {
+        self.builtin_lookup_dirty = true;
+    }
+
+    fn rebuild_builtin_segment_lookup(&mut self) {
+        self.builtin_segment_lookup.clear();
+        for (index, runner) in self
             .builtin_runners
             .iter()
             .chain(self.simulated_builtin_runners.iter())
+            .enumerate()
         {
-            if runner.base() as isize == address.segment_index {
-                return runner
-                    .deduce_memory_cell(address, memory)
-                    .map_err(VirtualMachineError::RunnerError);
+            let base = runner.base();
+            if base >= self.builtin_segment_lookup.len() {
+                self.builtin_segment_lookup
+                    .resize(base + 1, Self::NO_BUILTIN);
+            }
+            // First runner wins, matching the linear scan this lookup replaces.
+            if self.builtin_segment_lookup[base] == Self::NO_BUILTIN {
+                self.builtin_segment_lookup[base] = index as u32;
             }
         }
-        Ok(None)
+        self.builtin_lookup_dirty = false;
+    }
+
+    fn deduce_memory_cell(
+        &mut self,
+        address: Relocatable,
+    ) -> Result<Option<MaybeRelocatable>, VirtualMachineError> {
+        if self.builtin_lookup_dirty {
+            self.rebuild_builtin_segment_lookup();
+        }
+        let index = usize::try_from(address.segment_index)
+            .ok()
+            .and_then(|segment| self.builtin_segment_lookup.get(segment).copied())
+            .unwrap_or(Self::NO_BUILTIN);
+        if index == Self::NO_BUILTIN {
+            return Ok(None);
+        }
+        let index = index as usize;
+        let runner = if index < self.builtin_runners.len() {
+            &self.builtin_runners[index]
+        } else {
+            &self.simulated_builtin_runners[index - self.builtin_runners.len()]
+        };
+        runner
+            .deduce_memory_cell(address, &self.segments.memory)
+            .map_err(VirtualMachineError::RunnerError)
     }
 
     ///Computes the value of res if possible
@@ -692,7 +740,7 @@ impl VirtualMachine {
     }
 
     fn compute_op0_deductions(
-        &self,
+        &mut self,
         op0_addr: Relocatable,
         res: &mut Option<MaybeRelocatable>,
         instruction: &Instruction,
@@ -714,7 +762,7 @@ impl VirtualMachine {
     }
 
     fn compute_op1_deductions(
-        &self,
+        &mut self,
         op1_addr: Relocatable,
         res: &mut Option<MaybeRelocatable>,
         instruction: &Instruction,
@@ -741,7 +789,7 @@ impl VirtualMachine {
     /// Compute operands and result, trying to deduce them if normal memory access returns a None
     /// value.
     pub fn compute_operands(
-        &self,
+        &mut self,
         instruction: &Instruction,
     ) -> Result<(Operands, OperandsAddresses, DeducedOperands), VirtualMachineError> {
         //Get operands from memory
@@ -1047,7 +1095,20 @@ impl VirtualMachine {
 
     /// Returns a mutable reference to the vector with all builtins present in the virtual machine
     pub fn get_builtin_runners_as_mut(&mut self) -> &mut Vec<BuiltinRunner> {
+        self.builtin_lookup_dirty = true;
         &mut self.builtin_runners
+    }
+
+    /// Returns the simulated builtin runners present in the virtual machine
+    pub fn get_simulated_builtin_runners(&self) -> &Vec<BuiltinRunner> {
+        &self.simulated_builtin_runners
+    }
+
+    /// Returns a mutable reference to the vector with the simulated builtin runners present in
+    /// the virtual machine
+    pub fn get_simulated_builtin_runners_as_mut(&mut self) -> &mut Vec<BuiltinRunner> {
+        self.builtin_lookup_dirty = true;
+        &mut self.simulated_builtin_runners
     }
 
     /// Returns a mutable iterator over all builtin runners used. That is, both builtin_runners and
@@ -1055,6 +1116,7 @@ impl VirtualMachine {
     pub fn get_all_builtin_runners_as_mut_iter(
         &mut self,
     ) -> impl Iterator<Item = &mut BuiltinRunner> {
+        self.builtin_lookup_dirty = true;
         self.builtin_runners
             .iter_mut()
             .chain(self.simulated_builtin_runners.iter_mut())
@@ -1480,6 +1542,8 @@ impl VirtualMachineBuilder {
             run_context: self.run_context,
             builtin_runners: self.builtin_runners,
             simulated_builtin_runners: Vec::new(),
+            builtin_segment_lookup: Vec::new(),
+            builtin_lookup_dirty: true,
             extended_resource_counter: HashMap::new(),
             trace: self.trace,
             current_step: self.current_step,
@@ -3829,7 +3893,7 @@ mod tests {
 
     #[test]
     fn deduce_memory_cell_no_pedersen_builtin() {
-        let vm = vm!();
+        let mut vm = vm!();
         assert_matches!(vm.deduce_memory_cell(Relocatable::from((0, 0))), Ok(None));
     }
 


### PR DESCRIPTION
`deduce_memory_cell` linearly scanned all builtin runners on every op0/op1 memory miss. Keep a segment→runner lookup, rebuilt lazily when the runner set may have changed (a dirty flag set by the mut accessors).

**BREAKING**: `builtin_runners` and `simulated_builtin_runners` are now `pub(crate)`; external users go through the accessors (`get_builtin_runners`, `get_builtin_runners_as_mut`, and the new `get_simulated_builtin_runners`/`get_simulated_builtin_runners_as_mut`), which invalidate the lookup. `compute_operands` now takes `&mut self`.

Based on #2391.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Performance

**Expected:** `deduce_memory_cell` runs on every op0/op1 memory miss (up to twice per step) and previously scanned every builtin runner, calling the enum-matched `base()` on each. With `--layout all_cairo --proof_mode` a dozen runners are always present, so even builtin-free programs pay for the scan. The lookup makes it one array index.

**Measured** (best-of-7 vs parent #2391 branch, local; noise ±2.4%): improves everything with frequent deduce misses —

| benchmark | delta | | benchmark | delta |
|---|---|---|---|---|
| pedersen | −7.2% | | poseidon_integration | −4.8% |
| big_fibonacci | −6.1% | | math_integration | −4.8% |
| dict_integration | −4.9% | | big_factorial | −4.7% |
| memory_integration | −3.1% | | secp_integration | −2.2% |

keccak −2.2%, linear_search −2.5%, uint256 −1.2%, integration_builtins −0.4% (last two within noise). Note big_fibonacci improves despite using no builtins: under all_cairo layout the runner list is populated regardless, so the removed scan cost applies to every program.
*Methodology: `cairo_programs/benchmarks/*.cairo` compiled with cairo-lang 0.14 `--proof_mode`, run via `cairo-vm-cli <prog>.json --layout all_cairo --proof_mode`, hyperfine best-of-7 per binary, local x86-64 Linux. Noise floor (identical-code control pair): ±2.4%.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo-vm/2394)
<!-- Reviewable:end -->

