### PR TITLE
perf: avoid heap allocs reading Blake2s opcode operands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Both branches support Stwo prover opcodes (Blake2s, QM31) since v2.0.0.
 ---
 
 #### Upcoming Changes
+* perf: read the Blake2s opcode state/message via a stack array instead of a `Vec` per operand. BREAKING: removed the (unreachable) `VirtualMachineError::Blake2sInvalidOperand` variant [#2397](https://github.com/starkware-libs/cairo-vm/pull/2397)
+
 * perf: reduce per-instruction overhead in VM execution hot paths (memory get/insert, range-check validation, instruction cache, operand deduction) [#2391](https://github.com/starkware-libs/cairo-vm/pull/2391)
 
 * ci: pin GitHub Actions to commit SHAs and bump deprecated `upload-artifact`/`download-artifact` to v4 [#2388](https://github.com/starkware-libs/cairo-vm/pull/2388)

--- a/vm/src/vm/errors/vm_errors.rs
+++ b/vm/src/vm/errors/vm_errors.rs
@@ -135,8 +135,6 @@ pub enum VirtualMachineError {
     MismatchReturnFPOffset(Box<(Relocatable, Relocatable)>),
     #[error("Return FP felt { } should equal expected final FP { } offset", (*.0).0, (*.0).1)]
     MismatchReturnFPFelt(Box<(Felt252, Relocatable)>),
-    #[error("Blake2s opcode invalid operand: op{0} does not point to {1} u32 numbers.")]
-    Blake2sInvalidOperand(u8, u8),
     #[error("Blake2s opcode invalid flags {0}")]
     InvalidBlake2sFlags(u128),
     #[error("QM31 add mul opcode invalid flags {0}")]

--- a/vm/src/vm/vm_core.rs
+++ b/vm/src/vm/vm_core.rs
@@ -538,23 +538,17 @@ impl VirtualMachine {
     ) -> Result<(), VirtualMachineError> {
         let counter = self.segments.memory.get_u32(operands_addresses.dst_addr)?;
 
-        let state: [u32; 8] = (self.get_u32_range(
+        let state: [u32; 8] = self.segments.memory.get_u32_array(
             self.segments
                 .memory
                 .get_relocatable(operands_addresses.op0_addr)?,
-            8,
-        )?)
-        .try_into()
-        .map_err(|_| VirtualMachineError::Blake2sInvalidOperand(0, 8))?;
+        )?;
 
-        let message: [u32; 16] = (self.get_u32_range(
+        let message: [u32; 16] = self.segments.memory.get_u32_array(
             self.segments
                 .memory
                 .get_relocatable(operands_addresses.op1_addr)?,
-            16,
-        )?)
-        .try_into()
-        .map_err(|_| VirtualMachineError::Blake2sInvalidOperand(1, 16))?;
+        )?;
 
         let f0 = if is_last_block { 0xffffffff } else { 0 };
 

--- a/vm/src/vm/vm_memory/memory.rs
+++ b/vm/src/vm/vm_memory/memory.rs
@@ -829,6 +829,19 @@ impl Memory {
         Ok(values)
     }
 
+    /// Gets the `N` u32 values from addr to addr + N as an array, avoiding the heap allocation
+    /// of `get_u32_range`.
+    pub fn get_u32_array<const N: usize>(
+        &self,
+        addr: Relocatable,
+    ) -> Result<[u32; N], MemoryError> {
+        let mut values = [0; N];
+        for (i, value) in values.iter_mut().enumerate() {
+            *value = self.get_u32((addr + i)?)?;
+        }
+        Ok(values)
+    }
+
     fn get_cell(&self, addr: Relocatable) -> Option<&MemoryCell> {
         let (i, j) = from_relocatable_to_indexes(addr);
         let data = if addr.segment_index < 0 {


### PR DESCRIPTION
Read the Blake2s state and message via a new `get_u32_array` (const-generic stack array) instead of `get_u32_range`'s `Vec` — two heap allocations per Blake instruction removed.

**BREAKING**: the `Blake2sInvalidOperand` error variant was unreachable (the vec always had the requested size on success) and is removed.

Based on #2391.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Performance

**Expected:** removes two heap allocations (a `Vec<u32>` of 8 and of 16) per Blake2s **opcode** instruction — relevant only to Stwo-style programs using the Blake opcode, roughly proportional to their Blake instruction density.

**Measured** (best-of-7 vs parent #2391 branch, local; noise ±2.4%): the standard benchmark suite contains no Blake-opcode programs, so the direct effect is not exercised. The suite nonetheless showed a consistent −1% to −9% (all 12 benchmarks negative, e.g. big_factorial −8.8%, big_fibonacci −7.3%); since the touched code is unreachable in these programs, that is most plausibly a code-layout/alignment side effect of the error-variant removal rather than an attributable algorithmic gain — treat the direct win as unmeasured pending a Blake-opcode workload.
*Methodology: `cairo_programs/benchmarks/*.cairo` compiled with cairo-lang 0.14 `--proof_mode`, run via `cairo-vm-cli <prog>.json --layout all_cairo --proof_mode`, hyperfine best-of-7 per binary, local x86-64 Linux. Noise floor (identical-code control pair): ±2.4%.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/cairo-vm/2397)
<!-- Reviewable:end -->

